### PR TITLE
Remove unnecessary lines in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,10 @@ npm i @petoc/leaflet-double-touch-drag-zoom
 
 ```js
 import L from 'leaflet';
-import DoubleTouchDragZoom from '@petoc/leaflet-double-touch-drag-zoom';
-
 import 'leaflet/dist/leaflet.css';
-import '@petoc/leaflet-double-touch-drag-zoom/src/leaflet-double-touch-drag-zoom.css';
 
-L.Map.addInitHook('addHandler', 'doubleTouchDragZoom', DoubleTouchDragZoom);
+import '@petoc/leaflet-double-touch-drag-zoom';
+import '@petoc/leaflet-double-touch-drag-zoom/src/leaflet-double-touch-drag-zoom.css';
 
 const map = L.map('map', {
     center: [48.6726, 19.6994],

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Leaflet plugin for one finger zoom.
 
 ## Demo
 
-https://petoc.github.io/Leaflet.DoubleTouchDragZoom/example/
+<https://petoc.github.io/Leaflet.DoubleTouchDragZoom/example/>
 
 ## Usage
 
@@ -14,9 +14,8 @@ npm i @petoc/leaflet-double-touch-drag-zoom
 
 ```js
 import L from 'leaflet';
-import 'leaflet/dist/leaflet.css';
-
 import '@petoc/leaflet-double-touch-drag-zoom';
+import 'leaflet/dist/leaflet.css';
 import '@petoc/leaflet-double-touch-drag-zoom/src/leaflet-double-touch-drag-zoom.css';
 
 const map = L.map('map', {


### PR DESCRIPTION
It turns out that when the component is loaded, it already runs this snippet ([in this line](https://github.com/petoc/Leaflet.DoubleTouchDragZoom/blob/08df7984b937a5dd4e18074df3823604cf8aac7d/src/leaflet-double-touch-drag-zoom.js#L210)):

```ts
L.Map.addInitHook('addHandler', 'doubleTouchDragZoom', DoubleTouchDragZoom);
```

So there is no need to run it after importing `DoubleTouchDragZoom`.

